### PR TITLE
Adding logo link to DATS.json

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -180,6 +180,14 @@
       ]
     },
     {
+      "category": "logo",
+      "values": [
+        {
+          "value": "eegnet-logo_0.png"
+        }
+      ]
+    },
+    {
       "category": "REB_statement",
       "values": [
         {


### PR DESCRIPTION
This PR adds a `logo` value in the `extraProperties` section of the DATS.json file.