### PR TITLE
add origin_consortium value to DATS.json

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -171,6 +171,14 @@
         }
       ]
     },
+	{
+            "category": "origin_consortium",
+            "values": [
+                {
+                    "value": "EEGnet"
+                }
+            ]
+        },
     {
       "category": "contact",
       "values": [


### PR DESCRIPTION
This PR adds the value "EEGnet" to the `origin_consortium` field in DATS.json.